### PR TITLE
Open FirebaseUI Auth sign in screen if user is not logged in.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
     // Firebase
     compile 'com.google.firebase:firebase-database:9.6.0'
+    compile 'com.google.firebase:firebase-auth:9.6.0'
+
+    // FirebaseUI
+    compile 'com.firebaseui:firebase-ui-auth:0.6.0'
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Set Providers is deprecated. Use setAvailableProviders

So the else statement would contains this block-
List<AuthUI.IdpConfig> providers = Arrays.asList(
                            new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build(),
                            new AuthUI.IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build(),
                            new AuthUI.IdpConfig.Builder(AuthUI.PHONE_VERIFICATION_PROVIDER).build()
                    );

                    startActivityForResult(
                            AuthUI.getInstance()
                                    .createSignInIntentBuilder()
                                    .setIsSmartLockEnabled(false)
                                    .setAvailableProviders(providers)
                                    .build(),
                            RC_SIGN_IN);